### PR TITLE
updated README.md for kms and tls-kms-demo to smooth demo for 2 sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ On a Linux(e.g. Ubuntu) system apt-get can be used to install the programs below
 ##### kms.conf
 
 Applications like qTox and tls-kms-demo require kms.conf to be present under
-$HOME/.kms.
+$HOME/.qkd/kms/.
 
 This file can be manually created by puting following entries:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 qkd-net
 =======
 
+Note: this project runs in a Linux (e.g. Ubuntu) or Mac environment with bash.  Minor tweaks of the scripts are needed for it to work in a Windows environment.  General knowledge and skills of working with Linux/Mac including using terminal command line tools are required. 
+
+The top level directory of this project is referred to as *qkd-net* in the rest of this document.
 Overview
 --------
 
@@ -55,7 +58,7 @@ Ideally, QLL consists of working QKD devices. A QLL simulator is provided in thi
 
 #### Prerequisites (Required)
 
-Install following before proceeding.
+Install the following before proceeding.
 Make sure the executables are in system path.
 
 1. Java SDK 8 or later - http://www.oracle.com/technetwork/java/javase/downloads/index.html
@@ -65,7 +68,7 @@ Make sure the executables are in system path.
 
 #### Prerequisites for testing (Optional)
 
-On a Linux(Ubuntu) system apt-get can be used to install the programs.
+On a Linux(e.g. Ubuntu) system apt-get can be used to install the programs below.
 
 1. Curl
 2. jq
@@ -74,7 +77,7 @@ On a Linux(Ubuntu) system apt-get can be used to install the programs.
 
 ##### kms.conf
 
-Applications like qTox and tls-demo require kms.conf to be present under
+Applications like qTox and tls-kms-demo require kms.conf to be present under
 $HOME/.kms.
 
 This file can be manually created by puting following entries:
@@ -85,24 +88,25 @@ http://localhost:8095/api/getkey<br/>
 C<br/>
 
 
-Depending on where the KMS node is, localhost is replaced by the IP address of
-the host. Last line represents the KMS site id. It should be updated with the
+Depending on where the KMS node is, *localhost* is replaced by *the IP address* of
+the KMS node. Last line represents the KMS site id. It **should be updated** with the
 correct site id. Above is just an example.
 
 ##### config-repo
 
-config-repo directory under $HOME/ contains all the configuration property
-files required by all the microservices.
+The directory *$HOME/config-repo* contains all the configuration property
+files required by all the microservices in KMS and QNL.
 
-All the files reside under <top level directory>/qkd-net/kms/config-repo from where
-they are copied to $HOME/config-repo and checked in local git repository.
+All the files reside under *qkd-net/kms/config-repo* are copied to *$HOME/config-repo* and checked in local git repository.
 
 ##### site.properties
 
-This file is located under <top level directory>/qkd-net/kms/kms-service/src/main/resources/.
+This file is located under *qkd-net/kms/kms-service/src/main/resources/*.
 
 Explanation of site specific configuration properties used by KMS service
 
+// kms site ID
+kms.site.id=B
 //Number of keys per block<br/>
 kms.keys.blocksize=1024<br/>
 //Size of a key in bytes<br/>
@@ -138,8 +142,7 @@ poolLoc: kms/pools<br/>
 
 ###### routes.json:
 
-This file is copied from <top level directory>/qkd-net/qnl/conf/ to
-$HOME/.qkd/qnl.
+This file is copied from *qkd-net/qnl/conf/* to *$HOME/.qkd/qnl*.
 
 Topology information is contained in route.json.
 Currently this information is populated manually.
@@ -147,13 +150,12 @@ There are two sections here, one mentioning nodes which are adjacent
 and the other, non-adjacent. Adjacent nodes section contains the name
 of the node as key and it's IP address as the value.
 Non-adjacent nodes section contians name of the node as key and the name of
-the node it's reachable from as value. Key's value here will always be one
+the node it's reachable from as value. The node for value here will always be one
 of the nodes mentioned in the adjacent nodes section.   
 
 ###### config.yaml:
 
-This file is copied from <top level directory>/qkd-net/qnl/conf/ to
-$HOME/.qkd/qnl.
+This file is copied from *qkd-net/qnl/conf/* to *$HOME/.qkd/qnl*.
 
 Contains various configuration parameters for the key routing service
 running as a network layer.
@@ -238,22 +240,24 @@ There are two endpoints:
 Application at site B makes a newkey call.
 
 Request
-
+```
   Method :      POST
   URL path :    /api/newkey
   URL params:   siteid=[alhpanumeric] e.g. siteid=A
+```
 
 Response
   Format JSON
-
+```
 {
   index: Index of he key
   hexKey: Key in hexadecimal format
   blockId: Id of the block containing the key
 }
-
+```
 e.g. request-response:
 
+```
 curl 'http://localhost:8095/api/newkey?siteid=A' -H"Authorization: Bearer 291a94d5-d624-4269-a2bb-07db62130bb3" | jq
 
 {
@@ -261,7 +265,7 @@ curl 'http://localhost:8095/api/newkey?siteid=A' -H"Authorization: Bearer 291a94
   "hexKey": "a2e1ff3429ff841f5d469893b9c28cbcb586d55c8ecf98c83c704824e889fc43"
   "blockId": ""
 }
-
+```
 2. Get Key
 
 Application on site A makes the getkey call by using the response from the
@@ -272,23 +276,24 @@ Since the sites are different hence OAuth tokens will be different. Which
 means a new OAuth token like above is fetched first.
 
 Request
-
+```
   Method :      POST
   URL path :    /api/getkey
   URL params:   siteid=[alhpanumeric] e.g. siteid=B
                 blockid=
                 index=[Integer]
+```
 Response
   Format JSON
-
+```
   {
     index: Index of he key
     hexKey: Key in hexadecimal format
     blockId: Id of the block containing the key
   }
-
+```
 e.g. request-response:
-
+```
 curl 'http://localhost:8095/api/getkey?siteid=B&index=1&blockid=' -H"Authorization: Bearer abcdef12-d624-4269-a2bb-07db62130bb3" | jq
 
 {
@@ -296,15 +301,15 @@ curl 'http://localhost:8095/api/getkey?siteid=B&index=1&blockid=' -H"Authorizati
   "hexKey": "4544a432fb045f4940e1e2fe005470e1a35d85ede55f78927ca80f46a0a4b045"
   "blocId": ""
 }
-
+```
 TEAM
 ----
 
-The Open QKD Network project is led by Professors [Michele Mosca](http://faculty.iqc.uwaterloo.ca/mmosca/) and [Norbert Lutkenhaus[(http://services.iqc.uwaterloo.ca/people/profile/nlutkenh) at Institute for Quantum Computing (IQC) of the University of Waterloo.
+The Open QKD Network project is led by Professors [Michele Mosca](http://faculty.iqc.uwaterloo.ca/mmosca/) and [Norbert Lutkenhaus](http://services.iqc.uwaterloo.ca/people/profile/nlutkenh) at Institute for Quantum Computing (IQC) of the University of Waterloo.
 
 ### Contributors
 
 Contributors to this master branch of qkd-net include:
 
 - Shravan Mishra (University of Waterloo)
-- Xinhua Ling (University of Waterloo)
+- Xinhua Ling (University of Waterloo, XLNTEC Inc.)

--- a/applications/tls-kms-demo/README.md
+++ b/applications/tls-kms-demo/README.md
@@ -4,53 +4,55 @@ KMS (Key Management Service) demo
 Description
 -----------
 
-KMS demo comprises 3 applications:
+The tls-kms-demo comprises 2 user applications to demo a file transfer over a TLS channel using a pre-shared-key (PSK) obtained from KMS via API calls as described in [kms](https://github.com/open-qkd-net/qkd-net/kms):
 
-1. alice
-2. bob
+1. *alice* - the client connecting to a file server to upload a file
+2. *bob* - the file server accepting a file upload
 
-Network topology for the demo assumes the two KMS's connected to their respective QKD hardware, which is connected through a direct QKD link, for getting 
-keys. This simple setup avoids key routing as would be needed in a real world setup.
+Network topology for the demo assumes the two KMS's connected to their respective QKD hardware, which is connected through a direct QKD link, for getting keys. This simple setup avoids key routing as would be needed in a real world setup.
 
 kms application serves keys to it's clients.
 
-alice and bob programs are based on client-server architecture. alice can
-be assumed to be a browser and bob, a webserver.
+*alice* and *bob* programs are based on client-server architecture. *alice* can
+be assumed to be a browser and *bob*, a webserver.
 
-alice and bob communicate over TLS using PSK-AES256-CBC-SHA cipher suite.
+*alice* and *bob* communicate over TLS using PSK-AES256-CBC-SHA cipher suite.
 
-alice and bob obtain their pre-shared keys from their respective kms. 
+*alice* and *bob* obtain their pre-shared keys from their respective kms. 
 
-Following sequence of steps take place between alice and bob for establising
+Following sequence of steps take place between *alice* and *bob* for establising
 a TLS connection:
 
 
-1. alice initiates connection with bob.
-2. bob accepts alice's connection.
-3. bob initiates a connection with its kms for a fresh pre-shared
-   secret key to be used to establish connection with alice.
-4. bob's kms replies with a pre-shared secret key and its index within the key
+1. *alice* initiates connection with *bob*.
+2. *bob* accepts *alice*'s connection.
+3. *bob* initiates a connection with its kms for a fresh pre-shared
+   secret key to be used to establish connection with *alice*.
+4. *bob*'s kms replies with a pre-shared secret key and its index within the key
    bitstream.
-5. bob sends the index of the key as a pre-shared key hint to alice.
-6. alice receives the pre-shared secret key hint as index into the key bitstream.
-7. alice initiates a connection with its kms, sending the index of the key
-   received from bob, obtaining the exact pre-shared key that bob has.
-8. alice uses the obtained key to establish a TLS connection with bob.
+5. *bob* sends the index of the key as a pre-shared key hint to *alice*.
+6. *alice* receives the pre-shared secret key hint as index into the key bitstream.
+7. *alice* initiates a connection with its kms, sending the index of the key
+   received from *bob*, obtaining the exact pre-shared key that *bob* has.
+8. *alice* uses the obtained key to establish a TLS connection with *bob*.
 
 Pre-requisites
 --------------
-
+```
 1. sudo apt-get install libjson-c-dev
 2. sudo apt-get install openssl libssl-dev
 3. sudo apt-get install libcurl4-openssl-dev
-
+```
+**Important note:** currently the site id of alice and bob is hard coded in the *site_id* funciton in *src/bob.c*.  You'll need to change the hardcoded IP addresses in that function to reflect your specific lab setup to make the demo work.
 
 Build
 -----
 
-On command line cd to kms demo folder and run the following command to build the above three applications:
+On command line cd to *qkd-net/applications/tls-kms-demo* folder and run the following command to build the above three applications:
 
+```
 make
+```
 
 Run
 ===
@@ -58,57 +60,57 @@ Run
 Configuration
 -------------
 
-Before running alice or bob, please make sure file kms.conf is available under
+Before running *alice* or *bob*, please make sure file *kms.conf* is available under
 
 $HOME/.kms folder
 
-Also make sure id of the KMS is properly set.
-
-It is mentioned on the last line in the file kms.conf. 
-
-
+Also make sure the *site id* of the KMS is properly set in the following files:
+- $HOME/.qkd/kms/site.properties
+- $HOME/.qkd/qnl/config.yaml
+- $HOME/.kms/kms.conf
 
 Help
 ----
 
 For program options supplying -h will give various options the program can run
 with e.g.:
-
+```
 ./bob -h
+```
 
-alice
+*alice*
 -----
 
-alice connecting to bob running on port 10446 and ip address 129.97.41.204, 
-n port 10445 and sending a file Whale.mp3 to bob:
+*alice* connecting to *bob* running on port 10446 and ip address 129.97.41.204, and sending a file Whale.mp3 to *bob*:
 
+```
+./alice -b 10446 -i 129.97.41.204  -f data/Whale.mp3 
+```
 
-./alice -b 10446 -i 129.97.41.204  -f Whale.mp3 
-
-
-Output from alice:
-
+Output from *alice*:
+```
 -- Successfully conected to Bob
     -- Received PSK identity hint '5'
     -- Successfully connected to KMS ...
     -- Received PSK identity hint 'KMS'
-
-bob
+```
+*bob*
 ---
 
-bob running on port 10446 and talking to its kms running on port 10445.
-For the demo purposes it outputs the data in a file called bobdemo.
-
+*bob* runs on port 10446 and talks to its kms.
+For the demo purposes it outputs the data in a file called *bobdemo*.
+```
 ./bob  -b 10446 -f bobdemo
+```
 
-Output from bob when alice connects and sends data:
-
+Output from *bob* when *alice* connects and sends data:
+```
  -- Bob is listening for incomming connections on port 10445 ...
  -- Bob's KMS listening for incomming connections on port 10446 ...
     -- Successfully connected to KMS ...
     -- Received PSK identity hint 'KMS'
     -- SHA1 of the received key : A0862843C0180AFA3AED0A77A08D5D2D8A0B27BE
-
+```
 
 Simulate QKD hardware
 ---------------------

--- a/applications/tls-kms-demo/src/bob.c
+++ b/applications/tls-kms-demo/src/bob.c
@@ -125,9 +125,9 @@ err:
 
 static char* site_id(char* ip) {
 
-	if (strcmp(ip, "192.168.9.168") == 0)
+	if (strcmp(ip, "192.168.1.29") == 0)
 		return "B";
-	else if (strcmp(ip, "192.168.9.121") == 0)
+	else if (strcmp(ip, "192.168.1.35") == 0)
 		return "A";
 	else
 		return "C";

--- a/applications/tls-kms-demo/src/common.c
+++ b/applications/tls-kms-demo/src/common.c
@@ -12,7 +12,7 @@ static const char *query_str = "siteid=";
 
 
 void prepare_kms_access(struct Net_Crypto *m) {
-  char *str = "/.qkd/kms/kms.conf";
+  char *str = "/.kms/kms.conf";
   FILE *fp;
   char buffer[128];
   

--- a/applications/tls-kms-demo/src/common.c
+++ b/applications/tls-kms-demo/src/common.c
@@ -12,7 +12,7 @@ static const char *query_str = "siteid=";
 
 
 void prepare_kms_access(struct Net_Crypto *m) {
-  char *str = "/.kms/kms.conf";
+  char *str = "/.qkd/kms/kms.conf";
   FILE *fp;
   char buffer[128];
   

--- a/kms/kms-qnl-service/src/main/resources/config.yaml
+++ b/kms/kms-qnl-service/src/main/resources/config.yaml
@@ -1,4 +1,4 @@
 port: 9393
 keyByteSz: 32
-keyBlockSz: 4 
+keyBlockSz: 1024 
 poolLoc: kms/pools


### PR DESCRIPTION
- updated the two README.md files
- change the original file to be copied to $HOME/.qkd/kms/qnl/config.yaml on keyBlockSz from 4 to 1024
- fixed the tls-kms-demo/src/common.c to look for $HOME/.kms/kms.conf as described in the kms README.md
