### PR TITLE
Add support for key sources using ETSI 014 

### DIFF
--- a/kms/kms-qnl-service/src/main/java/com/uwaterloo/iqc/kms/qnl/ServerHandler.java
+++ b/kms/kms-qnl-service/src/main/java/com/uwaterloo/iqc/kms/qnl/ServerHandler.java
@@ -62,7 +62,7 @@ public class ServerHandler extends SimpleChannelInboundHandler<ByteBuf> {
             resp.setOpId(QNLConstants.RESP_POST_ALLOC_KP_BLOCK);
             resp.setSiteIds(qReq.getSrcSiteId(), qReq.getDstSiteId());
             resp.setUUID(qReq.getUUID());
-            resp.setKeyBlockIndex(qReq.getKeyBlockIndex());
+            resp.setKeyIdentifier(qReq.getKeyIdentifier());
             resp.setRespOpId(qReq.getRespOpId());
             binDest = new byte[blockByteSz];
             qReq.getPayLoad().readBytes(binDest);

--- a/qnl/key-routing-service/pom.xml
+++ b/qnl/key-routing-service/pom.xml
@@ -75,6 +75,43 @@
                 <artifactId>json-simple</artifactId>
                 <version>1.1.1</version>
         </dependency>
+      <dependency>
+          <groupId>com.squareup.okhttp3</groupId>
+          <artifactId>okhttp</artifactId>
+          <version>4.10.0</version>
+      </dependency>
+
+      <dependency>
+          <groupId>com.squareup.okhttp3</groupId>
+          <artifactId>logging-interceptor</artifactId>
+          <version>3.12.1</version>
+      </dependency>
+      <dependency>
+          <groupId>io.gsonfire</groupId>
+          <artifactId>gson-fire</artifactId>
+          <version>1.8.5</version>
+      </dependency>
+
+      <dependency>
+          <groupId>javax.ws.rs</groupId>
+          <artifactId>javax.ws.rs-api</artifactId>
+          <version>2.0</version>
+      </dependency>
+      <dependency>
+          <groupId>io.swagger</groupId>
+          <artifactId>swagger-annotations</artifactId>
+          <version>1.6.6</version>
+      </dependency>
+      <dependency>
+          <groupId>io.github.hakky54</groupId>
+          <artifactId>sslcontext-kickstart</artifactId>
+          <version>7.4.6</version>
+      </dependency>
+      <dependency>
+          <groupId>io.github.hakky54</groupId>
+          <artifactId>sslcontext-kickstart-for-pem</artifactId>
+          <version>7.4.6</version>
+      </dependency>
   </dependencies>
   <build>
     <extensions>
@@ -85,6 +122,27 @@
         </extension>
     </extensions>
   	<plugins>
+        <plugin>
+            <groupId>org.openapitools</groupId>
+            <artifactId>openapi-generator-maven-plugin</artifactId>
+            <!-- RELEASE_VERSION -->
+            <version>6.0.1</version>
+            <!-- /RELEASE_VERSION -->
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>generate</goal>
+                    </goals>
+                    <configuration>
+                        <inputSpec>${project.basedir}/src/main/resources/ETSI_GS_QKD_014_v1.1.1.yaml</inputSpec>
+                        <generatorName>java</generatorName>
+                        <configOptions>
+                            <sourceFolder>src/gen/java/main</sourceFolder>
+                        </configOptions>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
 	    <plugin>
             <groupId>org.xolstice.maven.plugins</groupId>
             <artifactId>protobuf-maven-plugin</artifactId>
@@ -115,7 +173,15 @@
                 <mainClass>com.uwaterloo.iqc.qnl.KeyRouter</mainClass>
              </configuration>
   		</plugin>
-  	</plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <source>8</source>
+                <target>8</target>
+            </configuration>
+        </plugin>
+    </plugins>
   </build>
   <properties>
     <io.grpc.version>1.39.0</io.grpc.version>
@@ -124,7 +190,7 @@
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
     <junit.version>4.12</junit.version>
     <protobuf.version>3.17.2</protobuf.version>
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
   </properties>
 </project>

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/KeyRouter.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/KeyRouter.java
@@ -17,7 +17,6 @@ import com.uwaterloo.iqc.qnl.qll.cqptoolkit.server.KeyTransferServer;
 import com.cqp.remote.*;
 
 import java.io.IOException;
-import java.io.ObjectInputFilter.Config;
 import java.util.Map;
 import java.util.Timer;
 import java.util.ArrayList;

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/KeyRouter.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/KeyRouter.java
@@ -35,7 +35,6 @@ public class KeyRouter{
           qConfig = new QNLConfiguration(args[0]);
 
         final KeyTransferServer server = new KeyTransferServer(qConfig);
-          qConfig.createOTPKeys(server);
         server.start();
 
         //GrpcClient client = new GrpcClient();

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/KeyRouter.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/KeyRouter.java
@@ -34,32 +34,33 @@ public class KeyRouter{
         else
           qConfig = new QNLConfiguration(args[0]);
 
-        final KeyTransferServer server = new KeyTransferServer(qConfig);
-        server.start();
+        if (qConfig.getConfig().getLegacyQLL()) {
+            final KeyTransferServer server = new KeyTransferServer(qConfig);
+            server.start();
 
-        //GrpcClient client = new GrpcClient();
-        //client.getSiteDetails("localhost", 8000);
-        //client.startNode("localhost", 8000, "localhost", 8001);
-	
-        //TODO: investigate auto-generating siteagent.json, and/or find a way to communicate requirement of having such a file
+            //GrpcClient client = new GrpcClient();
+            //client.getSiteDetails("localhost", 8000);
+            //client.startNode("localhost", 8000, "localhost", 8001);
 
-        LOGGER.info("starting site agent a");
-        final ISiteAgentServer siteAgent = new ISiteAgentServer(qConfig.getSiteAgentConfig().url, qConfig.getSiteAgentConfig().port);
-        try {
-          siteAgent.start();
-        } catch(IOException e) {
-          LOGGER.error("Unable to start site agent", e);
+            //TODO: investigate auto-generating siteagent.json, and/or find a way to communicate requirement of having such a file
+
+                LOGGER.info("starting site agent a");
+                final ISiteAgentServer siteAgent = new ISiteAgentServer(qConfig.getSiteAgentConfig().url, qConfig.getSiteAgentConfig().port);
+                try {
+                  siteAgent.start();
+                } catch(IOException e) {
+                  LOGGER.error("Unable to start site agent", e);
+                }
+                LOGGER.info("finished starting site agent a");
+
+            //siteAgent.setMySiteAgentListener(new KeyRouter()); not needed now.
+
+            // passing the address of the current site along with the ISiteAgentServer object and other paramenters.
+            LinkCheck l = new LinkCheck(qConfig.getSiteAgentConfig().url, qConfig.getSiteAgentConfig().port, siteAgent, timers, qConfig);
+
+            //calling the timer to check the status of all dummy drivers associated with links with this site.
+            timer.schedule(l, 5000, 5000);
         }
-        LOGGER.info("finished starting site agent a");
-
-        //siteAgent.setMySiteAgentListener(new KeyRouter()); not needed now.
-
-        // passing the address of the current site along with the ISiteAgentServer object and other paramenters.
-        LinkCheck l = new LinkCheck(qConfig.getSiteAgentConfig().url, qConfig.getSiteAgentConfig().port, siteAgent, timers, qConfig);
-
-        //calling the timer to check the status of all dummy drivers associated with links with this site.
-        timer.schedule(l, 5000, 5000);
-
 
         LOGGER.info("Key router started, args.length:" + args.length);
 
@@ -84,7 +85,7 @@ public class KeyRouter{
 
     /*
     This was the functionality added when a listener existed. With the current implementation, there's no need for this.
-    
+
     @Override
     public void onDeviceRegistered(String deviceID) {
       //do not block this function

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/KeyRouterBackendHandler.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/KeyRouterBackendHandler.java
@@ -107,7 +107,7 @@ public class KeyRouterBackendHandler extends ChannelInboundHandlerAdapter {
                 e.printStackTrace();
             }
 
-            if (opId == QNLConstants.REQ_POST_KP_BLOCK_INDEX) {
+            if (opId == QNLConstants.RESP_POST_KP_BLOCK_INDEX) {
                 LOGGER.info("RESP_POST_KP_BLOCK_INDEX/writeResp to inboundChannel:" + inboundChannel + ", resp:"  + resp);
             } else {
                 LOGGER.info("RESP_GET_KP_BLOCK_INDEX/writeResp to inbound channel:" + inboundChannel + ", resp:" + resp);

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/KeyRouterBackendHandler.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/KeyRouterBackendHandler.java
@@ -58,10 +58,7 @@ public class KeyRouterBackendHandler extends ChannelInboundHandlerAdapter {
         String destSiteId = qResp.getDstSiteId();
         String srcSiteId = qResp.getSrcSiteId();
         QNLResponse resp = null;
-        long index;
         QLLReader qllRdr;
-        byte [] bin =  null;
-        byte [] hex = null;
 
         LOGGER.info("KeyRouterBackend/processResp:" + this + ",res:" + qResp);
         switch (opId) {
@@ -71,7 +68,7 @@ public class KeyRouterBackendHandler extends ChannelInboundHandlerAdapter {
             // C ---> B ---> A, A is localSiteId, send to B
             adjResp.setOpId(qResp.getRespOpId());
             adjResp.setSiteIds(qResp.getSrcSiteId(), qResp.getDstSiteId());
-            adjResp.setKeyBlockIndex(qResp.getKeyBlockIndex());
+            adjResp.setKeyIdentifier(qResp.getKeyIdentifier());
             adjResp.setUUID(qResp.getUUID());
 
             LOGGER.info("RESP_POST_ALLOC_KP_BLOCK/writeResp:" + adjResp);
@@ -95,12 +92,10 @@ public class KeyRouterBackendHandler extends ChannelInboundHandlerAdapter {
             // so adjSiteId is B
             adjSiteId = rConfig.getAdjacentId(destSiteId);
             LOGGER.info("adjSiteId:" + adjSiteId);
-            index = qResp.getKeyBlockIndex();
+            String keyId = qResp.getKeyIdentifier();
             try {
                 qllRdr = qConfig.getQLLReader(adjSiteId);
-                hex =  new byte[blockByteSz*2];
-                qllRdr.read(hex, cfg.getKeyBlockSz(), index);
-                bin = new Hex().decode(hex);
+                byte[] bin = qllRdr.read(keyId);
 
                 resp = new QNLResponse(blockByteSz);
                 resp.setOpId(QNLConstants.RESP_GET_ALLOC_KP_BLOCK);
@@ -145,7 +140,7 @@ public class KeyRouterBackendHandler extends ChannelInboundHandlerAdapter {
                     resp.setOpId(QNLConstants.RESP_POST_KP_BLOCK_INDEX);
                 }
                 resp.setSiteIds(qResp.getSrcSiteId(), qResp.getDstSiteId());
-                resp.setKeyBlockIndex(qResp.getKeyBlockIndex());
+                resp.setKeyIdentifier(qResp.getKeyIdentifier());
                 resp.setUUID(qResp.getUUID());
             } else {
                 //propagate the peer alloc block response

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/KeyRouterFrontendHandler.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/KeyRouterFrontendHandler.java
@@ -123,18 +123,16 @@ public class KeyRouterFrontendHandler extends ChannelInboundHandlerAdapter {
           adjSiteId = rConfig.getAdjacentId(destSiteId);
           retainConnectHandler(ctx, adjSiteId);
 
+          otpKey = qConfig.getOTPKey(adjSiteId);
+          String otpKeyIdent = otpKey.encode(binDest);
+
           req = new QNLRequest(blockByteSz);
           req.setOpId(QNLConstants.REQ_POST_PEER_ALLOC_KP_BLOCK);
           req.setSiteIds(qReq.getSrcSiteId(), qReq.getDstSiteId());
           req.setKeyIdentifier(qReq.getKeyIdentifier());
           req.setUUID(qReq.getUUID());
-          try {
-            otpKey = qConfig.getOTPKey(adjSiteId);
-            otpKey.otp(binDest);
-            req.setPayLoad(binDest);
-          } catch (Exception e) {
-            e.printStackTrace(System.out);
-          }
+          req.setOTPKeyIdentifier(otpKeyIdent);
+          req.setPayLoad(binDest);
 
           LOGGER.info("REQ_POST_KP_BLOCK_INDEX/generate new QNLRequest:" + req);
           ctx.fireChannelActive();
@@ -179,7 +177,8 @@ public class KeyRouterFrontendHandler extends ChannelInboundHandlerAdapter {
             // In this case next hop is A
             // qll(C->B) xor otp(B->A)
             otpKey = qConfig.getOTPKey(adjSiteId);
-            otpKey.otp(binDest);
+            String otpKeyIdent = otpKey.encode(binDest);
+            req.setOTPKeyIdentifier(otpKeyIdent);
             req.setPayLoad(binDest);
           } catch (Exception e) {
             e.printStackTrace(System.out);
@@ -208,7 +207,7 @@ public class KeyRouterFrontendHandler extends ChannelInboundHandlerAdapter {
           try {
             // qll(C->B) xor otp(B->A) xor otp(A->B) = qll(C->B)
             otpKey = qConfig.getOTPKey(adjSiteId);
-            otpKey.otp(binDest);
+            otpKey.decode(binDest, qReq.getOTPKeyIdentifier());
             req.setPayLoad(binDest);
           } catch (Exception e) {
             e.printStackTrace(System.out);
@@ -227,7 +226,7 @@ public class KeyRouterFrontendHandler extends ChannelInboundHandlerAdapter {
           try {
             // OTPKey should be key between localSite and previous hop
             otpKey = qConfig.getOTPKey(rConfig.getAdjacentId(srcSiteId));
-            otpKey.otp(binDest);
+            otpKey.decode(binDest, qReq.getOTPKeyIdentifier());
           } catch (Exception e) {
             LOGGER.error("cannot get OTP key to decode the REQ_POST_PEER_ALLOC_KP_BLOCK payload");
             e.printStackTrace(System.out);
@@ -244,7 +243,8 @@ public class KeyRouterFrontendHandler extends ChannelInboundHandlerAdapter {
           req.setUUID(qReq.getUUID());
           try {
             otpKey = qConfig.getOTPKey(adjSiteId);
-            otpKey.otp(binDest);
+            String otpKeyIdent = otpKey.encode(binDest);
+            req.setOTPKeyIdentifier(otpKeyIdent);
             req.setPayLoad(binDest);
           } catch (Exception e) {
             LOGGER.error(

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/KeyServerRouterInitializer.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/KeyServerRouterInitializer.java
@@ -31,7 +31,7 @@ public class KeyServerRouterInitializer extends ChannelInitializer<SocketChannel
         RouteConfig routeCfg = qConfig.getRouteConfig();
 
         for (String k : routeCfg.adjacent.keySet()) {
-            String [] ipPort = routeCfg.adjacent.get(k).split(":");
+            String [] ipPort = routeCfg.adjacent.get(k).address.split(":");
             int port = qConfig.getConfig().getPort();
             if (ipPort.length == 2)
                 port = Integer.valueOf(ipPort[1]);

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/OTPKey.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/OTPKey.java
@@ -3,88 +3,40 @@ package com.uwaterloo.iqc.qnl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-
-import org.apache.commons.codec.binary.Hex;
-
 import com.uwaterloo.iqc.qnl.qll.QLLReader;
-import com.uwaterloo.qkd.qnl.utils.QNLUtils;
 
-public class OTPKey implements KeyListener {
+public class OTPKey {
     private static Logger LOGGER = LoggerFactory.getLogger(OTPKey.class);
 
     private QNLConfiguration qnlConfig;
     private String id;
-    private byte[] otpKey;
-
-    public static final String OTPKEYNAME = "otpkey";
-    private boolean canRead = false;
 
     public OTPKey(QNLConfiguration qnlConfig, String id) {
+
         this.qnlConfig = qnlConfig;
         this.id = id;
         LOGGER.info("OTPKey.new:id=" + id);
-        createKey();
     }
 
-    public void otp(byte[] data) throws Exception {
+    public String encode(byte[] data) {
+        QLLReader qllRdr = qnlConfig.getQLLReader(id);
+        byte[] otpKey = new byte[data.length];
+        String keyIdentifier = qllRdr.readNextKey(otpKey, data.length);
+
+        int i = 0;
+        for (byte b : otpKey) {
+            data[i] = (byte) (b ^ data[i++]);
+        }
+
+        return keyIdentifier;
+    }
+
+    public void decode(byte[] data, String keyIdentifier) {
+        QLLReader qllRdr = qnlConfig.getQLLReader(id);
+        byte[] otpKey = qllRdr.read(keyIdentifier);
+
         int i = 0;
         for (byte b : otpKey)
             data[i] = (byte)(b ^ data[i++]);
-    }
-
-    public void onKeyGenerated() {
-        if (!this.canRead) {
-            this.canRead = true;
-            createKey();
-        }
-    }
-
-    public void reset() {
-        canRead = false;
-    }
-
-    private void createKey() {
-
-        if(!canRead) {
-            return;
-        }
-
-        QNLConfig config = qnlConfig.getConfig();
-        byte[] hex =  new byte[config.getKeyBlockSz()*config.getKeyBytesSz()*2];
-
-        try {
-
-           File otpF = new File(config.getOTPKeyLoc(id));
-           if (!otpF.exists()) {
-              otpF.mkdirs();
-           }
-
-        } catch(Exception e) {
-            java.io.StringWriter sw = new java.io.StringWriter();
-            java.io.PrintWriter pw = new java.io.PrintWriter(sw);
-            e.printStackTrace(pw);
-            LOGGER.error("OTPKey.createKey exception:" + e + ",stacktrace:" + sw.toString());
-        }
-
-        String otpFile = config.getOTPKeyLoc(id) + "/" + OTPKEYNAME;
-        File f = new File(otpFile);
-
-        if(!f.exists()) {
-
-            QLLReader QLLRdr = qnlConfig.getQLLReader(id);
-            String keyId = QLLRdr.getNextKeyId(config.getKeyBlockSz()*config.getKeyBytesSz());
-            byte[] binKey = QLLRdr.read(keyId);
-            hex = Hex.encodeHexString(binKey).getBytes();
-            LOGGER.info("OTPKey.writeKeys to :" + otpFile);
-            QNLUtils.writeKeys(hex, otpFile, config.getKeyBlockSz());
-
-        } else {
-            QNLUtils.readKeys(hex, otpFile, config.getKeyBlockSz());
-        }
-
-        try {
-            otpKey = new Hex().decode(hex);
-        } catch(Exception e) {}
     }
 }

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/OTPKey.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/OTPKey.java
@@ -4,7 +4,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.codec.binary.Hex;
 
@@ -74,9 +73,9 @@ public class OTPKey implements KeyListener {
         if(!f.exists()) {
 
             QLLReader QLLRdr = qnlConfig.getQLLReader(id);
-            AtomicLong ref = new AtomicLong(0);
-            QLLRdr.getNextBlockIndex(config.getKeyBlockSz(), ref);
-            QLLRdr.read(hex, config.getKeyBlockSz(), ref.get());
+            String keyId = QLLRdr.getNextKeyId(config.getKeyBlockSz()*config.getKeyBytesSz());
+            byte[] binKey = QLLRdr.read(keyId);
+            hex = Hex.encodeHexString(binKey).getBytes();
             LOGGER.info("OTPKey.writeKeys to :" + otpFile);
             QNLUtils.writeKeys(hex, otpFile, config.getKeyBlockSz());
 

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/QNLConfig.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/QNLConfig.java
@@ -18,6 +18,7 @@ public class QNLConfig {
     private String kmsIP;
     private int kmsPort;
     public Map<String, String> OTPConfig;
+    private boolean legacyQLL;
     public static final String KMS = "kms";
 
     public String getRouteConfigLoc() {
@@ -80,4 +81,7 @@ public class QNLConfig {
         return kmsIP;
     }
 
+    public boolean getLegacyQLL() {
+        return legacyQLL;
+    }
 }

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/QNLConfig.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/QNLConfig.java
@@ -18,7 +18,6 @@ public class QNLConfig {
     private String kmsIP;
     private int kmsPort;
     public Map<String, String> OTPConfig;
-    public static final String OTP_KEYBLOCKSZ = "keyBlockSz";
     public static final String KMS = "kms";
 
     public String getRouteConfigLoc() {
@@ -35,10 +34,6 @@ public class QNLConfig {
 
     public String getSiteAgentConfigLoc() {
         return System.getProperty("user.home") + "/" + base + "/" + siteAgentConfigLoc;
-    }
-
-    public String getOTPKeyLoc(String siteId) {
-        return System.getProperty("user.home") + "/" + base + "/" + OTPConfig.get("keyLoc") + "/" + siteId;
     }
 
     public String getBase() {
@@ -83,10 +78,6 @@ public class QNLConfig {
 
     public String getKmsIP() {
         return kmsIP;
-    }
-
-    public int getOTPKeyBlockSz() {
-        return Integer.valueOf(OTPConfig.get(OTP_KEYBLOCKSZ)).intValue();
     }
 
 }

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/QNLConfiguration.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/QNLConfiguration.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.gson.Gson;
 import com.google.gson.stream.JsonReader;
 
+import com.uwaterloo.iqc.qnl.qll.QLLETSIReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -122,7 +123,11 @@ public class QNLConfiguration {
 
     private void createQLLClients() {
         for (String k : routeCfg.adjacent.keySet()) {
-            qllClientMap.put(k, new QLLFileReaderWriter(k, config));
+            if (config.getLegacyQLL()) {
+                qllClientMap.put(k, new QLLFileReaderWriter(k, config));
+            } else {
+                qllClientMap.put(k, new QLLETSIReader(routeCfg.getAdjacentIdKME(k)));
+            }
         }
     }
 }

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/QNLConfiguration.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/QNLConfiguration.java
@@ -55,15 +55,17 @@ public class QNLConfiguration {
             routeCfg = gson.fromJson(routeReader, RouteConfig.class);
             routeReader.close();
 
-            JsonReader siteAgentReader = new JsonReader(new FileReader(config.getSiteAgentConfigLoc()));
-            siteAgentCfg = gson.fromJson(siteAgentReader, SiteAgentConfig.class);
-            siteAgentReader.close();
+            if (config.getLegacyQLL()) {
+                JsonReader siteAgentReader = new JsonReader(new FileReader(config.getSiteAgentConfigLoc()));
+                siteAgentCfg = gson.fromJson(siteAgentReader, SiteAgentConfig.class);
+                siteAgentReader.close();
 
-            for (String siteID: routeCfg.adjacent.keySet()) {
-                LOGGER.info("Parsing file: " + config.getQKDLinkConfigLoc(siteID));
-                JsonReader qkdLinkReader = new JsonReader(new FileReader(config.getQKDLinkConfigLoc(siteID)));
-                qkdLinkCfgMap.put(siteID, (QKDLinkConfig) gson.fromJson(qkdLinkReader, QKDLinkConfig.class));
-                qkdLinkReader.close();
+                for (String siteID : routeCfg.adjacent.keySet()) {
+                    LOGGER.info("Parsing file: " + config.getQKDLinkConfigLoc(siteID));
+                    JsonReader qkdLinkReader = new JsonReader(new FileReader(config.getQKDLinkConfigLoc(siteID)));
+                    qkdLinkCfgMap.put(siteID, (QKDLinkConfig) gson.fromJson(qkdLinkReader, QKDLinkConfig.class));
+                    qkdLinkReader.close();
+                }
             }
 
             createOTPKeys();
@@ -114,8 +116,6 @@ public class QNLConfiguration {
     private void createOTPKeys() {
         for (String k : routeCfg.adjacent.keySet()) {
             OTPKey key = new OTPKey(this, k);
-
-            String localDeviceId = qkdLinkCfgMap.get(k).localQKDDeviceId;
 
             otpKeyMap.put(k, key);
         }

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/QNLConfiguration.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/QNLConfiguration.java
@@ -65,6 +65,7 @@ public class QNLConfiguration {
                 qkdLinkReader.close();
             }
 
+            createOTPKeys();
             createQLLClients();
         } catch(Exception e) {
             java.io.StringWriter sw = new java.io.StringWriter();
@@ -109,12 +110,11 @@ public class QNLConfiguration {
         return otpKeyMap.get(id);
     }
 
-    public void createOTPKeys(KeyTransferServer server) {
+    private void createOTPKeys() {
         for (String k : routeCfg.adjacent.keySet()) {
             OTPKey key = new OTPKey(this, k);
 
             String localDeviceId = qkdLinkCfgMap.get(k).localQKDDeviceId;
-            server.addListener(localDeviceId, key);
 
             otpKeyMap.put(k, key);
         }

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/RouteConfig.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/RouteConfig.java
@@ -5,8 +5,22 @@ import java.util.Map;
 import com.uwaterloo.iqc.qnl.lsrp.LSRPRouter;
 
 public class RouteConfig {
-    //adjacent - key:siteid, value:ip address
-    public Map<String, String> adjacent;
+    public class Route {
+        public String address;
+        public KMEConfig kme;
+    }
+
+    public class KMEConfig {
+        public String name;
+        public String address;
+        public String remote_sae;
+        public String client_cert;
+        public String client_key;
+        public String client_key_password;
+        public String server_cert;
+    }
+
+    public Map<String, Route> adjacent;
     //non-adjacent -  key:siteid of non-adjacent node,
     //value:siteid of adjacent node through which the key
     //is reachable
@@ -36,7 +50,15 @@ public class RouteConfig {
 
     public String[] getAdjacentIdAddress(String key) {
         if (adjacent.containsKey(key)) {
-            return adjacent.get(key).split(":");
+            return adjacent.get(key).address.split(":");
+        }
+
+        return null;
+    }
+
+    public KMEConfig getAdjacentIdKME(String key) {
+        if (adjacent.containsKey(key)) {
+            return adjacent.get(key).kme;
         }
 
         return null;

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/lsrp/LSRPOutgoingClientInitializer.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/lsrp/LSRPOutgoingClientInitializer.java
@@ -23,7 +23,7 @@ public class LSRPOutgoingClientInitializer extends ChannelInitializer<SocketChan
     @Override
     public void initChannel(SocketChannel ch) {
         ch.pipeline().addLast("lsrp-outgong-response-decoder", new LSRPMessageDecoder());
-        ch.pipeline().addLast("loghandler", new LoggingHandler(LogLevel.INFO));
+        ch.pipeline().addLast("loghandler", new LoggingHandler(LogLevel.TRACE));
         ch.pipeline().addLast("lsrp-outgoing-response", new LSRPOutgoingClientHandler(this.router));
         ch.pipeline().addLast("lsrp-outgoing-request-encoder", new LSRPMessageEncoder());
         LOGGER.info("LSRPOutgoingClientInitializer.initChannel:" + this + ",channel:" + ch);

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/lsrp/LSRPRouter.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/lsrp/LSRPRouter.java
@@ -70,7 +70,7 @@ public class LSRPRouter {
     this.allNodes.put(this.mySiteId, self);
 
     for (String k : routeCfg.adjacent.keySet()) {
-      String[] ipPort = routeCfg.adjacent.get(k).split(":");
+      String[] ipPort = routeCfg.adjacent.get(k).address.split(":");
       int port = 9395;
       if (ipPort.length == 2) port = Integer.valueOf(ipPort[1]);
       LOGGER.info("Add neighbour:" + k + ",address:" + ipPort[0] + ",port:" + port);

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/lsrp/LSRPRouter.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/lsrp/LSRPRouter.java
@@ -174,6 +174,9 @@ public class LSRPRouter {
         // new LSRP of existing node
         nn.setFloodingTimeStamp(msg.getTimeStamp());
         update = true;
+      } else {
+        // message was received before, got it again due to a cycle
+        return;
       }
       o = nn;
     }

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/lsrp/LSRPServerRouterInitializer.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/lsrp/LSRPServerRouterInitializer.java
@@ -22,7 +22,7 @@ public class LSRPServerRouterInitializer extends ChannelInitializer<SocketChanne
   public void initChannel(SocketChannel ch) {
     LOGGER.info("Accepts connection: " + ch);
     // inbound decoder
-    ch.pipeline().addLast("loghandler", new LoggingHandler(LogLevel.INFO));
+    ch.pipeline().addLast("loghandler", new LoggingHandler(LogLevel.TRACE));
     ch.pipeline().addLast(new LSRPMessageDecoder());
     ch.pipeline().addLast(new LSRPIncomingClientHandler(this.router));
     ch.pipeline().addLast(new LSRPMessageEncoder());

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/qll/QLLETSIReader.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/qll/QLLETSIReader.java
@@ -1,0 +1,146 @@
+package com.uwaterloo.iqc.qnl.qll;
+
+import com.uwaterloo.iqc.qnl.RouteConfig;
+import nl.altindag.ssl.util.PemUtils;
+import nl.altindag.ssl.SSLFactory;
+import okhttp3.OkHttpClient;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.api.KeyApi;
+import org.openapitools.client.api.StatusApi;
+import org.openapitools.client.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.*;
+import java.io.*;
+import java.nio.file.Files;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import javax.net.ssl.X509ExtendedTrustManager;
+
+public class QLLETSIReader implements QLLReader {
+
+    private ApiClient client;
+    private KeyApi api;
+
+    private String otherSAEId;
+
+    private Map<UUID, Key> keys;
+
+    private static Logger LOGGER = LoggerFactory.getLogger(QLLETSIReader.class);
+
+    private static InputStream loadResource(String res) throws IOException {
+        File configFile = new File(res);
+        if (!configFile.isAbsolute()) {
+            String configLoc = System.getProperty("user.home") + "/.qkd/qnl";
+            configFile = new File(configLoc, res);
+        }
+        return Files.newInputStream(configFile.toPath());
+    }
+
+    public static OkHttpClient loadClient(RouteConfig.KMEConfig config) throws IOException {
+        SSLFactory.Builder sslFactoryBuilder = SSLFactory.builder();
+
+        // Set up the client identity
+        X509ExtendedKeyManager keyManager = PemUtils.loadIdentityMaterial(
+                loadResource(config.client_cert),
+                loadResource(config.client_key),
+                config.client_key_password != null ? config.client_key_password.toCharArray() : null);
+        sslFactoryBuilder.withIdentityMaterial(keyManager);
+
+        // If a root CA is configured, use that
+        if (config.server_cert != null) {
+            X509ExtendedTrustManager trustManager = PemUtils.loadTrustMaterial(loadResource(config.server_cert));
+            sslFactoryBuilder.withTrustMaterial(trustManager);
+        } else {
+            sslFactoryBuilder.withSystemTrustMaterial();
+        }
+        SSLFactory sslFactory = sslFactoryBuilder.build();
+
+        return new OkHttpClient.Builder()
+                .sslSocketFactory(sslFactory.getSslSocketFactory(), sslFactory.getTrustManager().get())
+                // Uncomment to disable hostname verification for debugging
+                // .hostnameVerifier((hostname, session) -> true)
+                .build();
+    }
+
+    public QLLETSIReader(RouteConfig.KMEConfig config) {
+        this.client = new ApiClient();
+        this.api = new KeyApi(this.client);
+        this.keys = new HashMap<>();
+
+        this.otherSAEId = config.remote_sae;
+
+        client.setBasePath("https://" + config.address + "/api/v1");
+        LOGGER.info("Connecting to API endpoint: {}", client.getBasePath());
+        try {
+            client.setHttpClient(loadClient(config));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        // TODO: Use status info to set key size bounds etc.
+        try {
+            Status status = new StatusApi(this.client).getStatus(this.otherSAEId);
+            LOGGER.info("ETSI server status:\n{}", status);
+        } catch (ApiException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Key getKey(int len) {
+        KeyRequest request = new KeyRequest();
+        request.setSize(len * 8);
+        try {
+            KeyContainer container = api.getKey(otherSAEId, request);
+            LOGGER.info("Received keys:\n{}", container);
+            return container.getKeys().get(0);
+        } catch (ApiException e) {
+            LOGGER.error("getKey failed", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Key getKeyById(String identifier) {
+        KeyIds ids = new KeyIds();
+        KeyInformationDto keyDTO = new KeyInformationDto();
+        keyDTO.setKeyID(UUID.fromString(identifier));
+        ids.addKeyIDsItem(keyDTO);
+        try {
+            KeyContainer container = api.getKeyWithKeyIds(otherSAEId, ids);
+            LOGGER.info("Received keys by id:\nP{}", container);
+            return container.getKeys().get(0);
+        } catch (ApiException e) {
+            LOGGER.error("getKeyWithKeyIds failed", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String getNextKeyId(int len) {
+        Key key = getKey(len);
+        keys.put(key.getKeyID(), key);
+        return key.getKeyID().toString();
+    }
+
+    @Override
+    public String readNextKey(byte[] dst, int len) {
+        Key key = getKey(len);
+        byte[] keyData = Base64.getDecoder().decode(key.getKey());
+        System.arraycopy(keyData, 0, dst, 0, len);
+        return key.getKeyID().toString();
+    }
+
+    @Override
+    public byte[] read(String identifier) {
+        UUID keyUUID = UUID.fromString(identifier);
+        if (keys.containsKey(keyUUID)) {
+            return Base64.getDecoder().decode(keys.remove(keyUUID).getKey());
+        }
+        Key key = getKeyById(identifier);
+        return Base64.getDecoder().decode(key.getKey());
+    }
+}

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/qll/QLLReader.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/qll/QLLReader.java
@@ -1,13 +1,31 @@
 package com.uwaterloo.iqc.qnl.qll;
 
+import javax.annotation.Nullable;
 import java.util.concurrent.atomic.AtomicLong;
 
 public interface QLLReader {
-    public int read(byte[] dst, int len, AtomicLong index);
+    /**
+     * Get the next available key ID for a key of the given length. The key data is stored locally
+     * until read() is called with the same identifier.
+     * @param len Length of key in bytes.
+     * @return Identifier of the key that is shared on the QLL.
+     */
+    String getNextKeyId(int len);
 
-    public void getNextBlockIndex(int len, AtomicLong index);
+    /**
+     * Get the next available key for a key of the given length.
+     * @param dst Buffer to write key data into. Must be exactly len bytes
+     * @param len Length of the key to retrieve in bytes.
+     * @return Identifier of the key that is shared on the QLL.
+     */
+    String readNextKey(byte[] dst, int len);
 
-    public int read(byte[] dst, int len, long offset);
+    // read key with given ID
 
-    public void write(long seqId, String keyHexString, String destinationSiteId);
+    /**
+     * Get key data of a key that has previously been allocated using getNextKeyId() or shared via the QLL.
+     * @param identifier Identifier of the key that is shared on the QLL.
+     * @return Raw key data.
+     */
+    byte[] read(String identifier);
 }

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/qll/cqptoolkit/server/ISiteAgentServer.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/qll/cqptoolkit/server/ISiteAgentServer.java
@@ -154,7 +154,7 @@ public class ISiteAgentServer { // wrapper class for start() stop() functionalit
                         RawKeys key = keys.next();
                         List<ByteString> byteStrList = key.getKeyDataList();
                         for(ByteString byteStr : byteStrList) {
-                            LOGGER.info("got key bytes: " + byteStr.toStringUtf8());
+                            LOGGER.trace("got key bytes: " + byteStr.toStringUtf8());
                             // TODO: find more elegant way to add List<ByteString> to arraylist
                             byte[] byteArr = byteStr.toByteArray();
                             for(byte b : byteArr) {

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/qll/cqptoolkit/server/KeyTransferServer.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/qll/cqptoolkit/server/KeyTransferServer.java
@@ -1,6 +1,7 @@
 package com.uwaterloo.iqc.qnl.qll.cqptoolkit.server;
 
 import com.uwaterloo.iqc.qnl.QNLConfiguration;
+import com.uwaterloo.iqc.qnl.qll.QLLFileReaderWriter;
 import com.uwaterloo.iqc.qnl.qll.QLLReader;
 import com.uwaterloo.iqc.qnl.KeyListener;
 
@@ -102,7 +103,7 @@ public class KeyTransferServer {
             // LOGGER.info("PEERID: " + peerID);
 
             QLLReader qllRdr = this.qConfig.getQLLReader(peerID);
-            qllRdr.write(keyMessage.getSeqID(), Hex.encodeHexString(keyMessage.getKey().toByteArray()), peerID);
+            ((QLLFileReaderWriter)qllRdr).write(keyMessage.getKey().toByteArray());
             if (this.keysMap.containsKey(qkdID)) {
                 this.keysMap.put(qkdID, this.keysMap.get(qkdID) + 1);
             } else {

--- a/qnl/key-routing-service/src/main/resources/ETSI_GS_QKD_014_v1.1.1.yaml
+++ b/qnl/key-routing-service/src/main/resources/ETSI_GS_QKD_014_v1.1.1.yaml
@@ -1,0 +1,227 @@
+openapi: 3.0.0
+info:
+  description: |
+    "014"
+  version: 1.1.1
+  title: "014"
+paths:
+  '/keys/{sae_id}/status':
+    get:
+      tags:
+        - Status
+      summary: Get status
+      operationId: getStatus
+      parameters:
+        - name: sae_id
+          in: path
+          description: Slave SAE ID
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/status'
+        '400':
+          description: Bad request format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Object not found
+        '503':
+          description: Error on the server side
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+  '/keys/{sae_id}/enc_keys':
+    post:
+      tags:
+        - Key
+      summary: Get key
+      operationId: getKey
+      parameters:
+        - name: sae_id
+          in: path
+          description: Slave SAE ID
+          required: true
+          schema:
+            type: string
+      requestBody:
+        $ref: '#/components/requestBodies/key_request'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/key_container'
+        '400':
+          description: Bad request format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Object not found
+        '503':
+          description: Error on the server side
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+  '/keys/{sae_id}/dec_keys':
+    post:
+      tags:
+        - Key
+      summary: Get key with Key Ids
+      operationId: getKeyWithKeyIds
+      parameters:
+        - name: sae_id
+          in: path
+          description: Master SAE ID
+          required: true
+          schema:
+            type: string
+      requestBody:
+        $ref: '#/components/requestBodies/key_ids'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/key_container'
+        '400':
+          description: Bad request format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Object not found
+        '503':
+          description: Error on the server side
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+components:
+  schemas:
+    status:
+      type: object
+      properties:
+        source_KME_ID:
+          type: string
+        target_KME_ID:
+          type: string
+        master_SAE_ID:
+          type: string
+        slave_SAE_ID:
+          type: string
+        key_size:
+          type: integer
+        stored_key_count:
+          type: integer
+        max_key_count:
+          type: integer
+        max_key_per_request:
+          type: integer
+        max_key_size:
+          type: integer
+        min_key_size:
+          type: integer
+        max_SAE_ID_count:
+          type: integer
+        status_extension:
+          type: string
+    key:
+      type: object
+      properties:
+        key_ID:
+          type: string
+          format: uuid
+        key_ID_extension:
+          type: string
+        key:
+          type: string
+        key_extension:
+          type: string
+    key_information_dto:
+      type: object
+      properties:
+        key_ID:
+          type: string
+          format: uuid
+        key_ID_extension:
+          type: string
+    key_ids:
+      type: object
+      properties:
+        key_IDs:
+          type: array
+          items:
+            $ref: '#/components/schemas/key_information_dto'
+        key_IDs_extension:
+          type: string
+    key_container:
+      type: object
+      properties:
+        keys:
+          type: array
+          items:
+            $ref: '#/components/schemas/key'
+        key_container_extension:
+          type: string
+    key_request:
+      type: object
+      properties:
+        number:
+          type: integer
+        size:
+          type: integer
+        additional_slave_SAE_IDs:
+          type: array
+          items:
+            type: string
+        extension_mandatory:
+          type: array
+          items:
+            type: string
+        extension_optional:
+          type: array
+          items:
+            type: string
+    error:
+      type: object
+      properties:
+        message:
+          type: string
+        details:
+          type: string
+  requestBodies:
+    key_request:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/key_request'
+      description: KeyRequest request DTO
+      required: true
+    key_ids:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/key_ids'
+      description: Key Ids request DTO
+      required: true

--- a/qnl/qnl-utils/pom.xml
+++ b/qnl/qnl-utils/pom.xml
@@ -17,7 +17,7 @@
 	</dependency>
   </dependencies>
   <properties>
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
   </properties>
 </project>

--- a/qnl/qnl-utils/src/main/java/com/uwaterloo/qkd/qnl/utils/QNLConstants.java
+++ b/qnl/qnl-utils/src/main/java/com/uwaterloo/qkd/qnl/utils/QNLConstants.java
@@ -3,12 +3,17 @@ package com.uwaterloo.qkd.qnl.utils;
 public class QNLConstants {
 
     //KMS-QNL OP
+    // Request a new key from the QNL keypool
     public static final short REQ_GET_ALLOC_KP_BLOCK = 1;
+    // Reply from QNL with key data
     public static final short REQ_POST_ALLOC_KP_BLOCK = 2;
 
     //QNL-QNL OP
+    // Unused
     public static final short REQ_POST_OTP_BLOCK_INDEX = 3;
+    // Push some key to KS, and return its index
     public static final short REQ_GET_KP_BLOCK_INDEX = 4;
+    // Push key with given index to KMS
     public static final short REQ_POST_KP_BLOCK_INDEX = 5;
     public static final short REQ_POST_PEER_ALLOC_KP_BLOCK = 6;
 
@@ -16,6 +21,7 @@ public class QNLConstants {
     public static final short RESP_GET_ALLOC_KP_BLOCK = 101;
     public static final short RESP_POST_ALLOC_KP_BLOCK = 102;
 
+    // Unused
     public static final short RESP_POST_OTP_BLOCK_INDEX = 103;
     public static final short RESP_GET_KP_BLOCK_INDEX = 104;
     public static final short RESP_POST_KP_BLOCK_INDEX = 105;

--- a/qnl/qnl-utils/src/main/java/com/uwaterloo/qkd/qnl/utils/QNLRequest.java
+++ b/qnl/qnl-utils/src/main/java/com/uwaterloo/qkd/qnl/utils/QNLRequest.java
@@ -8,21 +8,19 @@ import io.netty.buffer.Unpooled;
 public class QNLRequest {
 
     private String srcSiteId;
-    private int srcSiteIdLen;
     private String dstSiteId;
-    private int dstSiteIdLen;
     private short opId;
     private short respOpId;
-    private long keyBlockIndex;
-    private int kpBlockBytesSz;
+    private String keyIdentifier;
+    private int keyBytes;
     private int frameSz;
     private ByteBuf payBuf;
     private boolean payLoadMode = false;
     private String uuid;
 
-    public QNLRequest(int kpBlockByteSz) {
-        this.kpBlockBytesSz = kpBlockByteSz;
-        payBuf = Unpooled.buffer(kpBlockByteSz + 128);
+    public QNLRequest(int keyBytes) {
+        this.keyBytes = keyBytes;
+        payBuf = Unpooled.buffer(keyBytes + 128);
         frameSz = 0;
     }
 
@@ -53,22 +51,20 @@ public class QNLRequest {
         return uuid;
     }
 
-    public void setKeyBlockIndex(long index) {
-        frameSz += Long.BYTES;
-        keyBlockIndex = index;
+    public void setKeyIdentifier(String identifier) {
+        frameSz += identifier.length() + 2;
+        keyIdentifier = identifier;
     }
 
-    public long getKeyBlockIndex() {
-        return keyBlockIndex;
+    public String getKeyIdentifier() {
+        return keyIdentifier;
     }
 
     public void setSiteIds(String src, String dst) {
-        srcSiteIdLen = src.length();
-        frameSz += srcSiteIdLen + 2;
+        frameSz += src.length() + 2;
         srcSiteId = src;
 
-        dstSiteIdLen = dst.length();
-        frameSz += srcSiteIdLen + 2;
+        frameSz += dst.length() + 2;
         dstSiteId = dst;
     }
 
@@ -78,6 +74,18 @@ public class QNLRequest {
 
     public String getDstSiteId() {
         return dstSiteId;
+    }
+
+    private static String readString(ByteBuf frame) {
+        short len = frame.readShort();
+        byte [] src = new byte[len];
+        frame.readBytes(src);
+        return new String(src);
+    }
+
+    private static void writeString(ByteBuf frame, String data) {
+        frame.writeShort(data.length());
+        frame.writeBytes(data.getBytes());
     }
 
     public void encode(ByteBuf out) {
@@ -94,34 +102,33 @@ public class QNLRequest {
         case QNLConstants.REQ_POST_KP_BLOCK_INDEX:
             break;
         }
+
         out.writeInt(frameSz);
         out.writeShort(opId);
-        out.writeShort(srcSiteIdLen);
-        out.writeBytes(srcSiteId.getBytes(), 0, srcSiteIdLen);
-        out.writeShort(dstSiteIdLen);
-        out.writeBytes(dstSiteId.getBytes(), 0, dstSiteIdLen);
+        writeString(out, srcSiteId);
+        writeString(out, dstSiteId);
 
         switch (opId) {
-        case QNLConstants.REQ_GET_ALLOC_KP_BLOCK:
-        case QNLConstants.REQ_GET_KP_BLOCK_INDEX:
-            break;
         case QNLConstants.REQ_POST_ALLOC_KP_BLOCK:
-            out.writeShort(uuid.length());
-            out.writeBytes(uuid.getBytes(), 0, uuid.length());
-            out.writeLong(keyBlockIndex);
-            out.writeShort(respOpId);
-            out.writeBytes(payBuf);
-            break;
         case QNLConstants.REQ_POST_PEER_ALLOC_KP_BLOCK:
-            out.writeShort(uuid.length());
-            out.writeBytes(uuid.getBytes(), 0, uuid.length());
-            out.writeLong(keyBlockIndex);
+        case QNLConstants.REQ_POST_KP_BLOCK_INDEX:
+            writeString(out, uuid);
+            writeString(out, keyIdentifier);
+            break;
+        default:
+            break;
+        }
+
+        if (opId == QNLConstants.REQ_POST_ALLOC_KP_BLOCK) {
+            out.writeShort(respOpId);
+        }
+
+        switch (opId) {
+        case QNLConstants.REQ_POST_ALLOC_KP_BLOCK:
+        case QNLConstants.REQ_POST_PEER_ALLOC_KP_BLOCK:
             out.writeBytes(payBuf);
             break;
-        case QNLConstants.REQ_POST_KP_BLOCK_INDEX:
-            out.writeShort(uuid.length());
-            out.writeBytes(uuid.getBytes(), 0, uuid.length());
-            out.writeLong(keyBlockIndex);
+        default:
             break;
         }
     }
@@ -135,76 +142,44 @@ public class QNLRequest {
     }
 
     public boolean decode(ByteBuf frame) {
-        int m =  frame.readableBytes();
-        short uuidLen;
-        byte [] id;
-
         if (!this.payLoadMode) {
             frameSz = frame.readInt();
             this.opId = frame.readShort();
             frameSz -= Short.BYTES;
 
-            this.srcSiteIdLen = frame.readShort();
-            frameSz -= Short.BYTES;
-            byte [] src = new byte[srcSiteIdLen];
-            frame.readBytes(src);
-            this.srcSiteId = new String(src);
-            frameSz -= this.srcSiteIdLen;
+            this.srcSiteId = readString(frame);
+            frameSz -= Short.BYTES + this.srcSiteId.length();
 
-            this.dstSiteIdLen = frame.readShort();
-            frameSz -= Short.BYTES;
-            byte [] dst = new byte[dstSiteIdLen];
-            frame.readBytes(dst);
-            this.dstSiteId = new String(dst);
-            frameSz -= this.dstSiteIdLen;
+            this.dstSiteId = readString(frame);
+            frameSz -= Short.BYTES + this.dstSiteId.length();
 
             switch (opId) {
-            case QNLConstants.REQ_GET_ALLOC_KP_BLOCK:
-            case QNLConstants.REQ_GET_KP_BLOCK_INDEX:
-                break;
             case QNLConstants.REQ_POST_PEER_ALLOC_KP_BLOCK:
-                uuidLen = frame.readShort();
-                frameSz -= Short.BYTES;
-                id = new byte[uuidLen];
-                frame.readBytes(id);
-                this.uuid = new String(id);
-                frameSz -= uuidLen;
-
-                this.keyBlockIndex = frame.readLong();
-                frameSz -= Long.BYTES;
-
-                frameSz -= frame.readableBytes();
-                frame.readBytes(payBuf, frame.readableBytes());
-                payLoadMode = !(frameSz == 0);
-                break;
             case QNLConstants.REQ_POST_KP_BLOCK_INDEX:
-                uuidLen = frame.readShort();
-                frameSz -= Short.BYTES;
-                id = new byte[uuidLen];
-                frame.readBytes(id);
-                this.uuid = new String(id);
-                frameSz -= uuidLen;
-
-                frameSz -= Long.BYTES;
-                this.keyBlockIndex = frame.readLong();
-                break;
             case QNLConstants.REQ_POST_ALLOC_KP_BLOCK:
-                uuidLen = frame.readShort();
-                frameSz -= Short.BYTES;
-                id = new byte[uuidLen];
-                frame.readBytes(id);
-                this.uuid = new String(id);
-                frameSz -= uuidLen;
+                this.uuid = readString(frame);
+                frameSz -= Short.BYTES + this.uuid.length();
 
-                this.keyBlockIndex = frame.readLong();
-                frameSz -= Long.BYTES;
+                this.keyIdentifier = readString(frame);
+                frameSz -= Short.BYTES + this.keyIdentifier.length();
+                break;
+            default:
+                break;
+            }
 
+            if (opId == QNLConstants.REQ_POST_ALLOC_KP_BLOCK) {
                 this.respOpId = frame.readShort();
                 frameSz -= Short.BYTES;
+            }
 
+            switch (opId) {
+            case QNLConstants.REQ_POST_PEER_ALLOC_KP_BLOCK:
+            case QNLConstants.REQ_POST_ALLOC_KP_BLOCK:
                 frameSz -= frame.readableBytes();
                 frame.readBytes(payBuf, frame.readableBytes());
                 payLoadMode = !(frameSz == 0);
+                break;
+            default:
                 break;
             }
         } else {
@@ -247,7 +222,7 @@ public class QNLRequest {
         case QNLConstants.REQ_POST_PEER_ALLOC_KP_BLOCK:
         case QNLConstants.REQ_POST_ALLOC_KP_BLOCK:
         case QNLConstants.REQ_POST_KP_BLOCK_INDEX:
-            fmt.format("  KeyBlockIndex: %s%n", keyBlockIndex);
+            fmt.format("  KeyBlockIndex: %s%n", keyIdentifier);
             fmt.format("  UUID: %s%n", uuid);
             break;
         }

--- a/qnl/qnl-utils/src/main/java/com/uwaterloo/qkd/qnl/utils/QNLResponse.java
+++ b/qnl/qnl-utils/src/main/java/com/uwaterloo/qkd/qnl/utils/QNLResponse.java
@@ -9,20 +9,18 @@ public class QNLResponse {
     private int frameSz;
     private ByteBuf payBuf;
     private String srcSiteId;
-    private int srcSiteIdLen;
     private String dstSiteId;
-    private int dstSiteIdLen;
     private short opId;
     private short respOpId;
-    private long keyBlockIndex;
-    private int kpBlockBytesSz;
+    private String keyIdentifier;
+    private int keyBytes;
     private String uuid;
     private boolean payLoadMode =  false;
 
-    public QNLResponse(int kpBlockByteSz) {
+    public QNLResponse(int keyBytes) {
         frameSz = 0;
-        this.kpBlockBytesSz = kpBlockByteSz;
-        payBuf = Unpooled.buffer(kpBlockByteSz + 128);
+        this.keyBytes = keyBytes;
+        payBuf = Unpooled.buffer(keyBytes + 128);
     }
 
     public void setOpId(short op) {
@@ -52,22 +50,20 @@ public class QNLResponse {
         return uuid;
     }
 
-    public void setKeyBlockIndex(long index) {
-        frameSz += Long.BYTES;
-        keyBlockIndex = index;
+    public void setKeyIdentifier(String identifier) {
+        frameSz += identifier.length() + 2;
+        keyIdentifier = identifier;
     }
 
-    public long getKeyBlockIndex() {
-        return keyBlockIndex;
+    public String getKeyIdentifier() {
+        return keyIdentifier;
     }
 
     public void setSiteIds(String src, String dst) {
-        srcSiteIdLen = src.length();
-        frameSz += srcSiteIdLen + 2;
+        frameSz += src.length() + 2;
         srcSiteId = src;
 
-        dstSiteIdLen = dst.length();
-        frameSz += dstSiteIdLen + 2;
+        frameSz += dst.length() + 2;
         dstSiteId = dst;
     }
 
@@ -77,6 +73,18 @@ public class QNLResponse {
 
     public String getDstSiteId() {
         return dstSiteId;
+    }
+
+    private static String readString(ByteBuf frame) {
+        short len = frame.readShort();
+        byte [] src = new byte[len];
+        frame.readBytes(src);
+        return new String(src);
+    }
+
+    private static void writeString(ByteBuf frame, String data) {
+        frame.writeShort(data.length());
+        frame.writeBytes(data.getBytes());
     }
 
     public void encode(ByteBuf out) {
@@ -91,29 +99,24 @@ public class QNLResponse {
         }
         out.writeInt(frameSz);
         out.writeShort(opId);
-        out.writeShort(srcSiteIdLen);
-        out.writeBytes(srcSiteId.getBytes(), 0, srcSiteIdLen);
-        out.writeShort(dstSiteIdLen);
-        out.writeBytes(dstSiteId.getBytes(), 0, dstSiteIdLen);
+        writeString(out, srcSiteId);
+        writeString(out, dstSiteId);
 
         switch (opId) {
         case QNLConstants.RESP_POST_ALLOC_KP_BLOCK:
-            out.writeShort(uuid.length());
-            out.writeBytes(uuid.getBytes(), 0, uuid.length());
-            out.writeLong(keyBlockIndex);
+            writeString(out, uuid);
+            writeString(out, keyIdentifier);
             out.writeShort(respOpId);
             break;
         case QNLConstants.RESP_GET_ALLOC_KP_BLOCK:
-            out.writeShort(uuid.length());
-            out.writeBytes(uuid.getBytes(), 0, uuid.length());
+            writeString(out, uuid);
             out.writeBytes(payBuf);
             break;
         case QNLConstants.RESP_POST_PEER_ALLOC_KP_BLOCK:
         case QNLConstants.RESP_POST_KP_BLOCK_INDEX:
         case QNLConstants.RESP_GET_KP_BLOCK_INDEX:
-            out.writeShort(uuid.length());
-            out.writeBytes(uuid.getBytes(), 0, uuid.length());
-            out.writeLong(keyBlockIndex);
+            writeString(out, uuid);
+            writeString(out, keyIdentifier);
             break;
         }
     }
@@ -128,62 +131,41 @@ public class QNLResponse {
 
     public boolean decode(ByteBuf frame) {
         short uuidLen;
-        byte [] id;
 
         if (!this.payLoadMode) {
             frameSz = frame.readInt();
             this.opId = frame.readShort();
             frameSz -= Short.BYTES;
 
-            this.srcSiteIdLen = frame.readShort();
-            frameSz -= Short.BYTES;
-            byte [] src = new byte[srcSiteIdLen];
-            frame.readBytes(src);
-            this.srcSiteId = new String(src);
-            frameSz -= this.srcSiteIdLen;
+            this.srcSiteId = readString(frame);
+            frameSz -= Short.BYTES + this.srcSiteId.length();
 
-            this.dstSiteIdLen = frame.readShort();
-            frameSz -= Short.BYTES;
-            byte [] dst = new byte[dstSiteIdLen];
-            frame.readBytes(dst);
-            this.dstSiteId = new String(dst);
-            frameSz -= this.dstSiteIdLen;
+            this.dstSiteId = readString(frame);
+            frameSz -= Short.BYTES + this.dstSiteId.length();
+
+            switch (opId) {
+                case QNLConstants.RESP_POST_ALLOC_KP_BLOCK:
+                case QNLConstants.RESP_POST_KP_BLOCK_INDEX:
+                case QNLConstants.RESP_POST_PEER_ALLOC_KP_BLOCK:
+                case QNLConstants.RESP_GET_KP_BLOCK_INDEX:
+                case QNLConstants.RESP_GET_ALLOC_KP_BLOCK:
+                    this.uuid = readString(frame);
+                    frameSz -= Short.BYTES + this.uuid.length();
+                    if (opId != QNLConstants.RESP_GET_ALLOC_KP_BLOCK){
+                        this.keyIdentifier = readString(frame);
+                        frameSz -= Short.BYTES + this.keyIdentifier.length();
+                    }
+                    break;
+                default:
+                    break;
+            }
 
             switch (opId) {
             case QNLConstants.RESP_POST_ALLOC_KP_BLOCK:
-                uuidLen = frame.readShort();
-                frameSz -= Short.BYTES;
-                id = new byte[uuidLen];
-                frame.readBytes(id);
-                this.uuid = new String(id);
-                frameSz -= uuidLen;
-
-                this.keyBlockIndex = frame.readLong();
-                frameSz -= Long.BYTES;
-
                 this.respOpId = frame.readShort();
                 frameSz -= Short.BYTES;
                 break;
-            case QNLConstants.RESP_POST_KP_BLOCK_INDEX:
-            case QNLConstants.RESP_POST_PEER_ALLOC_KP_BLOCK:
-            case QNLConstants.RESP_GET_KP_BLOCK_INDEX:
-                uuidLen = frame.readShort();
-                frameSz -= Short.BYTES;
-                id = new byte[uuidLen];
-                frame.readBytes(id);
-                this.uuid = new String(id);
-                frameSz -= uuidLen;
-                this.keyBlockIndex = frame.readLong();
-                frameSz -= Long.BYTES;
-                break;
             case QNLConstants.RESP_GET_ALLOC_KP_BLOCK:
-                uuidLen = frame.readShort();
-                frameSz -= Short.BYTES;
-                id = new byte[uuidLen];
-                frame.readBytes(id);
-                this.uuid = new String(id);
-                frameSz -= uuidLen;
-
                 frameSz -= frame.readableBytes();
                 frame.readBytes(payBuf, frame.readableBytes());
                 payLoadMode = !(frameSz== 0);
@@ -231,7 +213,7 @@ public class QNLResponse {
         case QNLConstants.RESP_POST_KP_BLOCK_INDEX:
         case QNLConstants.RESP_POST_PEER_ALLOC_KP_BLOCK:
         case QNLConstants.RESP_GET_KP_BLOCK_INDEX:
-            fmt.format("  KeyBlockIndex: %s%n", keyBlockIndex);
+            fmt.format("  KeyBlockIndex: %s%n", keyIdentifier);
             fmt.format("  UUID: %s%n", uuid);
             break;
         }


### PR DESCRIPTION
This PR adds basic support for devices implementing the ETSI 014 REST interface as key source in the QNL key router service. In summary:

- Use OpenAPI spec to generate client API classes, use those to retrieve keys when ETSI has been configured;
- Modify key routing protocol to send key identifiers as plain strings (the existing backend encodes block index and offset as strings);
- Rework OTP key handling to fetch keys on demand. For each transmitted key, a new OTP key is used (which is more in line with how OTP keys should be used);
- Start CQP gRPC client/server only if not using the ETSI backend ('legacy' mode).

A bug was also fixed in the LRSP handling that prevent it from dealing with cycles properly.

The ETSI client simply requests entire key blocks at once. It is possible that a simulator/device does not support keys of that size, in which case the key block size should be reduced in the configuration (possibly to just a single 32 byte key).