### PR TITLE
Add RPC method for sending keys from SatelliteDriver

### DIFF
--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/qll/cqptoolkit/server/KeyTransferServer.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/qll/cqptoolkit/server/KeyTransferServer.java
@@ -120,13 +120,13 @@ public class KeyTransferServer {
 
         @Override
         public void onKeyFromCQP(Key keyMessage, StreamObserver<Empty> responseObserver) {
-            LOGGER.info("Received key from CQP.");
+            LOGGER.debug("Received key from CQP.");
             onKeyFromDriver(keyMessage, responseObserver);
         }
 
         @Override
         public void onKeyFromSatellite(Key keyMessage, StreamObserver<Empty> responseObserver) {
-            LOGGER.info("Received key from satellite.");
+            LOGGER.debug("Received key from satellite.");
             onKeyFromDriver(keyMessage, responseObserver);
         }
     }

--- a/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/qll/cqptoolkit/server/KeyTransferServer.java
+++ b/qnl/key-routing-service/src/main/java/com/uwaterloo/iqc/qnl/qll/cqptoolkit/server/KeyTransferServer.java
@@ -85,8 +85,7 @@ public class KeyTransferServer {
             keyListenerMap.put(id, k);
         }
 
-        @Override
-        public void onKeyFromCQP(Key keyMessage, StreamObserver<Empty> responseObserver) {
+        private void onKeyFromDriver(Key keyMessage, StreamObserver<Empty> responseObserver) {
             String myID = this.qConfig.getConfig().getSiteId();
             // LOGGER.info("SITEID: " + this.qConfig.getConfig().getSiteId());
             String qkdID = keyMessage.getLocalID();
@@ -117,6 +116,18 @@ public class KeyTransferServer {
                 KeyListener keyListener = keyListenerMap.get(qkdID);
                 keyListener.onKeyGenerated();
             }
+        }
+
+        @Override
+        public void onKeyFromCQP(Key keyMessage, StreamObserver<Empty> responseObserver) {
+            LOGGER.info("Received key from CQP.");
+            onKeyFromDriver(keyMessage, responseObserver);
+        }
+
+        @Override
+        public void onKeyFromSatellite(Key keyMessage, StreamObserver<Empty> responseObserver) {
+            LOGGER.info("Received key from satellite.");
+            onKeyFromDriver(keyMessage, responseObserver);
         }
     }
 }

--- a/qnl/key-routing-service/src/main/proto/KeyTransfer.proto
+++ b/qnl/key-routing-service/src/main/proto/KeyTransfer.proto
@@ -15,4 +15,5 @@ message Empty {}
 service KeyTransfer
 {
     rpc OnKeyFromCQP(Key) returns (Empty);
+    rpc OnKeyFromSatellite(Key) returns (Empty);
 }


### PR DESCRIPTION
Adds the OnKeyFromSatelliteDriver method to the KeyTransferServer.

In reality it is using the same code from OnKeyFromCQP as before. Just extracted it out so that they each can have different log messages for debugging purposes.